### PR TITLE
Work Around: Allow OneHit knife with any knife.

### DIFF
--- a/addons/sourcemod/scripting/myjailshop.sp
+++ b/addons/sourcemod/scripting/myjailshop.sp
@@ -1590,7 +1590,7 @@ public Action Hook_OnTakeDamage(int victim, int &attacker, int &inflictor, float
 				char weaponName[255];
 				GetClientWeapon(attacker, weaponName, sizeof(weaponName));
 				
-				if (StrEqual(weaponName, "weapon_knifegg"))
+				if (StrContains(weaponName, "knife") != -1)
 				{
 					damage = 1000.0;
 					return Plugin_Changed;


### PR DESCRIPTION
In this way the player that doesn't have the "normal knife", will be able to use the OneHit knife anyway.

More infos: https://forums.alliedmods.net/showthread.php?t=300987