### PR TITLE
Fixed throwing knives not working with Bayonets

### DIFF
--- a/addons/sourcemod/scripting/myjailshop.sp
+++ b/addons/sourcemod/scripting/myjailshop.sp
@@ -1414,7 +1414,7 @@ public void Event_WeaponFire(Event event, char[] name, bool dontBroadcast)
 	char weapon[20];
 	event.GetString("weapon", weapon, sizeof(weapon));
 
-	if (StrContains(weapon, "knife", false) == -1)
+	if ((StrContains(weapon, "knife", false) == -1) && !StrEqual(weapon, "bayonet"))
 		return;
 
 	int client = GetClientOfUserId(event.GetInt("userid"));

--- a/addons/sourcemod/scripting/myjailshop.sp
+++ b/addons/sourcemod/scripting/myjailshop.sp
@@ -1414,7 +1414,7 @@ public void Event_WeaponFire(Event event, char[] name, bool dontBroadcast)
 	char weapon[20];
 	event.GetString("weapon", weapon, sizeof(weapon));
 
-	if ((StrContains(weapon, "knife", false) == -1) && !StrEqual(weapon, "bayonet"))
+	if ((StrContains(weapon, "knife", false) == -1) && !StrEqual(weapon, "weapon_bayonet", false))
 		return;
 
 	int client = GetClientOfUserId(event.GetInt("userid"));


### PR DESCRIPTION
The throwing knives didn't work if you had a bayonet, this is because the bayonet is the only knife in csgo that doesn't have the "knife" string in it's entity name!

Added a simple detection for the bayonet